### PR TITLE
Add null check for argument which caused strange behavior

### DIFF
--- a/src/CommandLine.csproj
+++ b/src/CommandLine.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version>1.5.1</Version>
-    <AssemblyVersion>1.5.1.0</AssemblyVersion>
+    <Version>1.5.2</Version>
+    <AssemblyVersion>1.5.2.0</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
   </PropertyGroup>
 

--- a/src/Parser.cs
+++ b/src/Parser.cs
@@ -123,7 +123,9 @@ namespace CommandLine
             bool shouldExpand = false;
             for (int i = 0; i < args.Length; i++)
             {
-                if (args[i][0] == '@')
+                // it might be possible that the args[i] value is an empty string.
+                // we should check and make sure we have a valid value here before trying to check the '@' char
+                if (!string.IsNullOrEmpty(args[i]) && args[i][0] == '@')
                 {
                     shouldExpand = true;
                     break;
@@ -138,7 +140,7 @@ namespace CommandLine
 
             for (int i = 0; i < args.Length; i++)
             {
-                if (args[i][0] == '@')
+                if (!string.IsNullOrEmpty(args[i]) && args[i][0] == '@')
                 {
                     string fileName = args[i].Substring(1);
                     // does the file exist?
@@ -278,7 +280,7 @@ namespace CommandLine
 
         private static List<PropertyInfo> ParseOptionalParameters<TOptions>(string[] args, int offsetInArray, ArgumentGroupInfo TypeArgumentInfo, TOptions options, ref int currentLogicalPosition) where TOptions : new()
         {
-            // we are going to assume that all optionl parameters are not matched to values in 'args'
+            // we are going to assume that all optional parameters are not matched to values in 'args'
             List<PropertyInfo> unmatched = new List<PropertyInfo>(TypeArgumentInfo.OptionalArguments.Values);
             // process the optional arguments
             while (offsetInArray + currentLogicalPosition < args.Length)

--- a/test/CommandLineTests.Help.cs
+++ b/test/CommandLineTests.Help.cs
@@ -656,5 +656,31 @@ namespace CommandLine.Tests
                 new TextAndColor(ConsoleColor.Black, ")")
             );
         }
+
+        [Fact]
+        public void HelpWhenPassMoreParametersThanExpected()
+        {
+            TestWriter _printer = new TestWriter();
+
+            var options = Helpers.Parse<MorePassedInThanRequired>("this expects 2 args", _printer);
+
+             Validate(_printer,
+                new TextAndColor(ConsoleColor.Red, "Error"), 
+                new TextAndColor(ConsoleColor.Black, @": Optional parameter name should start with '-' 
+"), 
+                new TextAndColor(ConsoleColor.Black, "Usage: "), 
+                new TextAndColor(ConsoleColor.Black, " "), 
+                new TextAndColor(ConsoleColor.White, "testhost.exe"), 
+                new TextAndColor(ConsoleColor.Black, " "), 
+                new TextAndColor(ConsoleColor.Cyan, "a"), 
+                new TextAndColor(ConsoleColor.Black, " "), 
+                new TextAndColor(ConsoleColor.Cyan, "b"), 
+                new TextAndColor(ConsoleColor.Black, " "), 
+                new TextAndColor(ConsoleColor.Black, "For detailed information run '"), 
+                new TextAndColor(ConsoleColor.White, "testhost --help"), 
+                new TextAndColor(ConsoleColor.Black, "'." )
+             );
+        }
+
     }
 }

--- a/test/TestObjects/Negative.cs
+++ b/test/TestObjects/Negative.cs
@@ -51,4 +51,13 @@ namespace CommandLine.Tests
         [RequiredArgument(1, "a", "")]
         public Enum1 p1 { get; set; }
     }
+
+    internal class MorePassedInThanRequired
+    {
+        [RequiredArgument(0, "a", "")]
+        public string p1 { get; set; }
+
+        [RequiredArgument(1, "b", "")]
+        public string p2 { get; set; }
+    }
 }


### PR DESCRIPTION
It seems like there is a difference in behavior on .net core between standalone apps and shared apps.

For standalone apps, the host will translate `""` to an empty string. 
For shared app, that translation doesn't happen.

Fixes #32 

/cc @safern