### PR TITLE
Bump up dependencies.

### DIFF
--- a/analyzer/CommandLine.Analyzer.Test/CommandLine.Analyzer.Test.csproj
+++ b/analyzer/CommandLine.Analyzer.Test/CommandLine.Analyzer.Test.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLine.Net" Version="1.5.0" />
+    <PackageReference Include="CommandLine.Net" Version="2.1.2" />
     <PackageReference Include="coverlet.collector" Version="1.2.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2">
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />

--- a/analyzer/CommandLine.Analyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/analyzer/CommandLine.Analyzer.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -18,7 +18,7 @@ namespace TestHelper
     public abstract partial class DiagnosticVerifier
     {
         // this is relative based on the CommandLine project. We are using Path.Combine for X-Plat support
-        private static readonly MetadataReference PathToCommandLineAssemblyToReference = MetadataReference.CreateFromFile(typeof(Parser).Assembly.Location); //Path.Combine("..","..","..","..","..","bin","Debug","netstandard1.5","CommandLine.dll");
+        private static readonly MetadataReference PathToCommandLineAssemblyToReference = MetadataReference.CreateFromFile(typeof(Parser).Assembly.Location);
 
         private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location);
         private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
@@ -156,6 +156,9 @@ namespace TestHelper
                 refs.Add(MetadataReference.CreateFromFile(item));
             }
 
+            // add netStandard.dll to the mix
+            var ns20 = Path.Combine(pathToSharedFx, "netstandard.dll");
+            refs.Add(MetadataReference.CreateFromFile(ns20));
 
             var solution = new AdhocWorkspace()
                 .CurrentSolution

--- a/src/CommandLine.csproj
+++ b/src/CommandLine.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion>2.1.2</AssemblyVersion>
+    <AssemblyVersion>2.1.3</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
-    <VersionPrefix>2.1.2</VersionPrefix>
+    <VersionPrefix>2.1.3</VersionPrefix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/CommandLine.Tests.csproj
+++ b/test/CommandLine.Tests.csproj
@@ -11,9 +11,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.9.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/CommandLineTests.Environment.cs
+++ b/test/CommandLineTests.Environment.cs
@@ -6,6 +6,7 @@ namespace CommandLine.Tests
     public partial class CommandLineTests
     {
         [Fact]
+        [Trait("Category", "Environment variable")]
         public void EnvironmentTest1()
         {
             ParserOptions po = new ParserOptions() { VariableNamePrefix = nameof(EnvironmentTest1) };


### PR DESCRIPTION
This pulls in the CommandLine version with .NET Standard 2.0 support, meaning we need to pull in that dependency as well when building the project.

Also added a trait to one of the tests who was missing one.